### PR TITLE
fixing bug when switching from disabled to enabled

### DIFF
--- a/azir-core/azir-slider/index.tsx
+++ b/azir-core/azir-slider/index.tsx
@@ -74,7 +74,7 @@ const AzirSlider: React.FC<Props> = props => {
         })
       );
     }
-  }, [containerSize, thumbSize]);
+  }, [containerSize, thumbSize, disabled]);
   const _getValue = (gestureState: any) => {
     const length = containerSize.width - thumbSize.width;
     const thumbLeft = this._previousLeft + gestureState.dx;


### PR DESCRIPTION
the useEffect that creates the PanResponder events need to update with 'disabled' as a depedency, so that the functions '_handlePanResponderMove' and '_handlePanResponderEnd' can run with the updated value for the 'disabled' prop.

Without this, the component remained non interactable when you changed from 'disabled=true' to 'disabled=false'